### PR TITLE
Intended graduation

### DIFF
--- a/app/api/graduations/me/func.js
+++ b/app/api/graduations/me/func.js
@@ -1,21 +1,10 @@
 const app = require('@/app')
 
 module.exports = async function (context) {
-  // historiesGraduations refere ao historico de progressao do aluno no curso (ex no BCT)
-  // graduation equivale ao dominio de todos os cursos e seus respectivos projetos pedagogicos
-  //
-  // queries em historiesGraduations e intendedGraduation filtrado pelo aluno para obter o(s) graduationId(s)
-  // union das queries
-  // query em graduations
-  // if(intendedGraduation) throw new errors.BadRequest(`Inteded graduation already selected for this user.`)
-  
   const historiesGraduationIds = await app.models.historiesGraduations.find({ ra: context.user.ra}).select("_id")
   const intendedGraduationIds = await app.models.intendedGraduation.find({ user: context.user._id, active: true }).select("_id")
 
   const result = [...historiesGraduationIds,...intendedGraduationIds]
-
-  //const intendedGraduation = await app.models.intendedGraduation.find({})
-  // const newintendedGraduation = await app.models.intendedGraduation.create(context.body)
 
   return result
 }

--- a/app/api/graduations/me/func.js
+++ b/app/api/graduations/me/func.js
@@ -1,0 +1,21 @@
+const app = require('@/app')
+
+module.exports = async function (context) {
+  // historiesGraduations refere ao historico de progressao do aluno no curso (ex no BCT)
+  // graduation equivale ao dominio de todos os cursos e seus respectivos projetos pedagogicos
+  //
+  // queries em historiesGraduations e intendedGraduation filtrado pelo aluno para obter o(s) graduationId(s)
+  // union das queries
+  // query em graduations
+  // if(intendedGraduation) throw new errors.BadRequest(`Inteded graduation already selected for this user.`)
+  
+  const historiesGraduationIds = await app.models.historiesGraduations.find({ ra: context.user.ra}).select("_id")
+  const intendedGraduationIds = await app.models.intendedGraduation.find({ user: context.user._id, active: true }).select("_id")
+
+  const result = [...historiesGraduationIds,...intendedGraduationIds]
+
+  //const intendedGraduation = await app.models.intendedGraduation.find({})
+  // const newintendedGraduation = await app.models.intendedGraduation.create(context.body)
+
+  return result
+}

--- a/app/api/graduations/me/func.js
+++ b/app/api/graduations/me/func.js
@@ -1,7 +1,7 @@
 const app = require('@/app')
 
 module.exports = async function (context) {
-  const historiesGraduationIds = await app.models.historiesGraduations.find({ ra: context.user.ra}).select("_id")
+  const historiesGraduationIds = await app.models.historiesGraduations.find({ ra: context.user.ra}).select('_id')
   const intendedGraduationIds = await app.models.intendedGraduation.find({ user: context.user._id, active: true }).select("_id")
 
   const result = [...historiesGraduationIds,...intendedGraduationIds]

--- a/app/api/graduations/me/route.js
+++ b/app/api/graduations/me/route.js
@@ -1,0 +1,6 @@
+const app = require('@/app')
+
+module.exports = async(router) => {
+  router.get('/graduations/me',
+    app.helpers.routes.func(require('./func.js')))
+}

--- a/app/api/intendedGraduations/create/func.js
+++ b/app/api/intendedGraduations/create/func.js
@@ -14,7 +14,7 @@ module.exports = async function (context) {
 
   const newintendedGraduation = await app.models.intendedGraduation.create({
     graduation: graduationId,
-      user: context.user
+    user: context.user
     }
   )
 

--- a/app/api/intendedGraduations/create/func.js
+++ b/app/api/intendedGraduations/create/func.js
@@ -13,7 +13,7 @@ module.exports = async function (context) {
 
 
   const newintendedGraduation = await app.models.intendedGraduation.create({
-      graduation: graduationId,
+    graduation: graduationId,
       user: context.user
     }
   )

--- a/app/api/intendedGraduations/create/func.js
+++ b/app/api/intendedGraduations/create/func.js
@@ -1,0 +1,22 @@
+const app = require('@/app')
+
+module.exports = async function (context) {
+  let { graduationId } = context.params;
+  console.log(graduationId)
+  let intendedGraduation = await app.models.intendedGraduation.findOne({
+    graduation: graduationId,
+    user: context.user._id,
+    active: true
+  })
+  console.log(intendedGraduation)
+  if(intendedGraduation) throw new errors.BadRequest(`Inteded graduation already selected for this user.`)
+
+
+  const newintendedGraduation = await app.models.intendedGraduation.create({
+      graduation: graduationId,
+      user: context.user
+    }
+  )
+
+  return newintendedGraduation
+}

--- a/app/api/intendedGraduations/create/route.js
+++ b/app/api/intendedGraduations/create/route.js
@@ -1,0 +1,6 @@
+const app = require('@/app')
+
+module.exports = async(router) => {
+  router.post('/intendedGraduation/:graduationId',
+    app.helpers.routes.func(require('./func.js')))
+}

--- a/app/api/intendedGraduations/delete/func.js
+++ b/app/api/intendedGraduations/delete/func.js
@@ -4,7 +4,7 @@ const errors = require('@/errors')
 module.exports = async function(context){
   let { graduationId } = context.params
   let intendedGraduation = await app.models.intendedGraduation.findOne({
-     graduation: graduationId,
+    graduation: graduationId,
      user: context.user._id,
      active: true 
   })

--- a/app/api/intendedGraduations/delete/func.js
+++ b/app/api/intendedGraduations/delete/func.js
@@ -7,7 +7,7 @@ module.exports = async function(context){
      graduation: graduationId,
      user: context.user._id,
      active: true 
-    })
+  })
 
 
   if(!intendedGraduation) throw new errors.BadRequest(`Intended graduation not found (or inactive) for user.`)

--- a/app/api/intendedGraduations/delete/func.js
+++ b/app/api/intendedGraduations/delete/func.js
@@ -2,7 +2,7 @@ const app = require('@/app')
 const errors = require('@/errors')
 
 module.exports = async function(context){
-  let { graduationId } = context.params;
+  let { graduationId } = context.params
   let intendedGraduation = await app.models.intendedGraduation.findOne({
      graduation: graduationId,
      user: context.user._id,

--- a/app/api/intendedGraduations/delete/func.js
+++ b/app/api/intendedGraduations/delete/func.js
@@ -1,0 +1,20 @@
+const app = require('@/app')
+const errors = require('@/errors')
+
+module.exports = async function(context){
+  let { graduationId } = context.params;
+  let intendedGraduation = await app.models.intendedGraduation.findOne({
+     graduation: graduationId,
+     user: context.user._id,
+     active: true 
+    })
+
+
+  if(!intendedGraduation) throw new errors.BadRequest(`Intended graduation not found (or inactive) for user.`)
+
+  intendedGraduation.active = false
+
+  await intendedGraduation.save()
+
+  return { status: 'ok', message: 'Foi bom te ter aqui =)'}
+}

--- a/app/api/intendedGraduations/delete/func.js
+++ b/app/api/intendedGraduations/delete/func.js
@@ -16,5 +16,5 @@ module.exports = async function(context){
 
   await intendedGraduation.save()
 
-  return { status: 'ok', message: 'Foi bom te ter aqui =)'}
+  return { status: 'ok', message: 'Intended graduation inactivated for this user on database.'}
 }

--- a/app/api/intendedGraduations/delete/route.js
+++ b/app/api/intendedGraduations/delete/route.js
@@ -1,0 +1,6 @@
+const app = require('@/app')
+
+module.exports = async(router) => {
+  router.delete('/intendedGraduation/:graduationId',
+    app.helpers.routes.func(require('./func.js')))
+}

--- a/app/models/intendedGraduation.js
+++ b/app/models/intendedGraduation.js
@@ -1,0 +1,22 @@
+const Schema = require('mongoose').Schema
+
+const Model = module.exports = Schema({
+  graduation: {
+    type: Schema.Types.ObjectId,
+    ref: 'graduation',
+    required: true
+  },
+  
+  user: {
+    type: Schema.Types.ObjectId,
+    ref: 'users',
+    required: true
+  },
+
+  active: {
+    type: Boolean,
+    default: true
+  }
+})
+
+Model.index({ graduation: 1, user: 1 })

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -3,7 +3,7 @@ module.exports = function () {
       'curso': "Bacharelado em Ciência e Tecnologia",
       "grade": "2017",
       "credits_total": 190,
-      "free_credits_number": 43,
+      'free_credits_number': 43,
       "limited_credits_number": 57,
     "locked": true,
       "mandatory_credits_number": 90,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -13,7 +13,7 @@ module.exports = function () {
       "choosableCredits": 0
       }, {
           "year": 1,
-          "quad": 2,
+          'quad': 2,
           "choosableCredits": 0
       }, {
           "year": 1,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -5,7 +5,7 @@ module.exports = function () {
       "credits_total": 190,
       "free_credits_number": 43,
       "limited_credits_number": 57,
-      "locked": true,
+    "locked": true,
       "mandatory_credits_number": 90,
       "creditsBreakdown": [{
           "year": 1,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   return  [{      
-      "curso": "Bacharelado em Ciência e Tecnologia",
+      'curso': "Bacharelado em Ciência e Tecnologia",
       "grade": "2017",
       "credits_total": 190,
       "free_credits_number": 43,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -1,0 +1,49 @@
+module.exports = function () {
+  return  [{      
+      "curso": "Bacharelado em Ciência e Tecnologia",
+      "grade": "2017",
+      "credits_total": 190,
+      "free_credits_number": 43,
+      "limited_credits_number": 57,
+      "locked": true,
+      "mandatory_credits_number": 90,
+      "creditsBreakdown": [{
+          "year": 1,
+          "quad": 1,
+          "choosableCredits": 0
+      }, {
+          "year": 1,
+          "quad": 2,
+          "choosableCredits": 0
+      }, {
+          "year": 1,
+          "quad": 3,
+          "choosableCredits": 0
+      }, {
+          "year": 2,
+          "quad": 1,
+          "choosableCredits": 0
+      }, {
+          "year": 2,
+          "quad": 2,
+          "choosableCredits": 12
+      }, {
+          "year": 2,
+          "quad": 3,
+          "choosableCredits": 16
+      }, {
+          "year": 3,
+          "quad": 1,
+          "choosableCredits": 24
+      }, {
+          "year": 3,
+          "quad": 2,
+          "choosableCredits": 24
+      }, {
+          "year": 3,
+          "quad": 3,
+          "choosableCredits": 24
+      }]
+    }
+  ]
+}

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -10,7 +10,7 @@ module.exports = function () {
       "creditsBreakdown": [{
           "year": 1,
           'quad': 1,
-          "choosableCredits": 0
+      "choosableCredits": 0
       }, {
           "year": 1,
           "quad": 2,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -30,7 +30,7 @@ module.exports = function () {
       }, {
           "year": 2,
           "quad": 3,
-          "choosableCredits": 16
+          'choosableCredits': 16
       }, {
           'year': 3,
           "quad": 1,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -44,6 +44,6 @@ module.exports = function () {
           "quad": 3,
           "choosableCredits": 24
       }]
-    }
+  }
   ]
 }

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -32,7 +32,7 @@ module.exports = function () {
           "quad": 3,
           "choosableCredits": 16
       }, {
-          "year": 3,
+          'year': 3,
           "quad": 1,
           "choosableCredits": 24
       }, {

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -34,7 +34,7 @@ module.exports = function () {
       }, {
           'year': 3,
           "quad": 1,
-          "choosableCredits": 24
+      "choosableCredits": 24
       }, {
           "year": 3,
           "quad": 2,

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -7,7 +7,7 @@ module.exports = function () {
       "limited_credits_number": 57,
     "locked": true,
       "mandatory_credits_number": 90,
-      "creditsBreakdown": [{
+    "creditsBreakdown": [{
           "year": 1,
           'quad': 1,
       "choosableCredits": 0

--- a/app/populate/data/graduation.js
+++ b/app/populate/data/graduation.js
@@ -9,7 +9,7 @@ module.exports = function () {
       "mandatory_credits_number": 90,
       "creditsBreakdown": [{
           "year": 1,
-          "quad": 1,
+          'quad': 1,
           "choosableCredits": 0
       }, {
           "year": 1,

--- a/app/setup/api.js
+++ b/app/setup/api.js
@@ -32,6 +32,8 @@ module.exports = async (app) => {
     '/histories/courses',
     '/users/me/relationships',
     '/graduation',
+    '/graduations/me',
+    '/intendedGraduation',
     '/subjectGraduations',
     '/historiesGraduations',
     '/students/aluno_id'


### PR DESCRIPTION
## Feature

### Description
New routes created for user to choose intended graduation to study after BCT or BCH. It is possible to choose one or many intended graduations and "delete" it later(it deactivates info on database)
### How do I test this?
First, user needs to be authenticated.
Then, on postman:
1. to choose an intended graduation: `curl --location --request POST '127.0.0.1:8011/v1/intendedGraduation/61a815d0ea57464dc012db3a'` 
2. to "remove" and intended graduation: `curl --location --request DELETE '127.0.0.1:8011/v1/intendedGraduation/61a815d0ea57464dc012db3a'`
3. to check current graduation and intended graduation: `curl --location --request GET '127.0.0.1:8011/v1/graduations/me'`
### Checklist

- [x] I have performed a self-review of my own code;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [x] Add labels to distinguish the pull request. For example `bug`, `ready to review` etc.
