### PR TITLE
fix(oauth): add explicit api version to oauth facebook url

### DIFF
--- a/app/setup/oauth.js
+++ b/app/setup/oauth.js
@@ -17,7 +17,7 @@ async function facebook (context) {
   const { inApp = '', userId = '', env = '' } = _.get(context.session, 'grant.dynamic', {})
 
   const accessToken = context.query.access_token
-  const url = `https://graph.facebook.com/me?fields=id,name,email,picture.width(640)&metadata=1&access_token=${accessToken}`
+  const url = `https://graph.facebook.com/v18.0/me?fields=id,name,email,picture.width(640)&metadata=1&access_token=${accessToken}`
   const resp = await Axios.get(url)
 
   const faceUser = resp.data


### PR DESCRIPTION
## Bug

### Description
This PR adds a explicit api version to the oauth facebook url to potentially fix oauth facebook login errors

### How do I test this?
you can run the following command `curl -i -X GET "https://graph.facebook.com/v18.0/me?fields=id,name,email,picture.width(640)&metadata=1&access_token=YOUR_TOKEN` where you can get your token on Meta's [graph api explorer](https://developers.facebook.com/tools/explorer/). The response should have the header facebook-api-version set to v18.0 and a bunch of your facebook profile information

