### PR TITLE
fix: facebook recovery link and facebook login workaround

### DIFF
--- a/app/api/facebook/func.js
+++ b/app/api/facebook/func.js
@@ -1,15 +1,18 @@
-const app = require('@/app')
+const app = require("@/app");
 
 module.exports = async (context) => {
-  const { ra, email } = context.body
+  const { ra, email } = context.body;
 
-  const user = await app.models.users.findOne({ ra, 'oauth.emailFacebook': email })
-  
+  const user = await app.models.users.findOne({
+    ra,
+    $or: [{ "oauth.facebookEmail": email }, { "oauth.email": email }],
+  });
+
   if (!user) {
-    throw new Error('User does not exists')
+    throw new Error("User does not exists");
   }
 
   return {
-    token: user.generateJWT()
-  }
-}
+    token: user.generateJWT(),
+  };
+};

--- a/app/api/users/me/recover/func.js
+++ b/app/api/users/me/recover/func.js
@@ -23,7 +23,7 @@ module.exports = async function (context) {
   const payload = {
     recipient: user.email,
     body: {
-      recovery_facebook: `${RECOVERY_URL}/facebook?userId=${user._id}`,
+      recovery_facebook: "https://api.ufabcnext.com/facebook/sync",
       recovery_google: `${RECOVERY_URL}/google?userId=${user._id}`,
     },
   };


### PR DESCRIPTION
##  Bug

### Description
This PR will change the facebook account recovery link to a page we created to circumvent the problem where users couldn't login with their facebook accounts anymore. Also, the facebook workaround works with some edges cases where the oauth.facebookEmail isn't set correctly. 

It's also important to note that there was a problem with the SES recovery email template where the HTML wasn't set correctly so the SES couldn't send the recovery emails.

### How do I test this?
Try to recover your account using the facebook link, the email should be sent correctly and the link should redirect to the correct facebook workaround screen.



### Checklist

- [x] I have performed a self-review of my own code;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] Add labels to distinguish the pull request. For example `bug`, `ready to review` etc.
